### PR TITLE
Add single-key chord and drag-aim support for desktop mouse

### DIFF
--- a/packages/minesweeper/src/App.svelte
+++ b/packages/minesweeper/src/App.svelte
@@ -74,6 +74,7 @@
         onReveal: (r, c) => performAction("reveal", r, c),
         onFlag: (r, c) => performAction("flag", r, c),
         onChord: (r, c) => performAction("chord", r, c),
+        getBoard: () => game.board,
         isInteractive: () => game.isInteractive,
     });
 
@@ -186,7 +187,9 @@
             ? "😵"
             : game.gameStatus === GameStatus.Win
                 ? "😎"
-                : "😊"
+                : (mouse.isPressing || touch.isPressing)
+                    ? "😮"
+                    : "😊"
     );
 
     let minWidthClass = $derived(

--- a/packages/minesweeper/src/components/board/Board.svelte
+++ b/packages/minesweeper/src/components/board/Board.svelte
@@ -78,6 +78,7 @@
                 lastStepOnMine={game.revealedMinePos?.r === r && game.revealedMinePos?.c === c}
                 onMouseDown={mouse.onMouseDown}
                 onMouseUp={mouse.onMouseUp}
+                onMouseEnter={mouse.onMouseEnter}
                 onTouchStart={touch.onTouchStart}
                 onTouchEnd={touch.onTouchEnd}
             />

--- a/packages/minesweeper/src/components/board/Cell.svelte
+++ b/packages/minesweeper/src/components/board/Cell.svelte
@@ -11,6 +11,7 @@
         lastStepOnMine = false,
         onMouseDown,
         onMouseUp,
+        onMouseEnter,
         onTouchStart,
         onTouchEnd,
     }: {
@@ -23,6 +24,7 @@
         lastStepOnMine?: boolean;
         onMouseDown: (e: MouseEvent, r: number, c: number) => void;
         onMouseUp: (e: MouseEvent, r: number, c: number) => void;
+        onMouseEnter: (e: MouseEvent, r: number, c: number) => void;
         onTouchStart: (e: TouchEvent, r: number, c: number) => void;
         onTouchEnd: (e: TouchEvent, r: number, c: number) => void;
     } = $props();
@@ -39,6 +41,24 @@
         }
         return "";
     }
+
+    // Classic Minesweeper number palette. Dark-mode variants are lightened so
+    // they stay readable on the revealed cell's dark background.
+    const NUMBER_COLORS: Record<number, string> = {
+        1: "text-blue-600 dark:text-blue-400",
+        2: "text-green-700 dark:text-green-400",
+        3: "text-red-600 dark:text-red-400",
+        4: "text-indigo-800 dark:text-indigo-300",
+        5: "text-rose-800 dark:text-rose-400",
+        6: "text-teal-600 dark:text-teal-300",
+        7: "text-gray-900 dark:text-gray-200",
+        8: "text-gray-500 dark:text-gray-400",
+    };
+    const numberColor = $derived(
+        cell.isRevealed && !cell.isMine && cell.adjacentMines > 0
+            ? NUMBER_COLORS[cell.adjacentMines] ?? ""
+            : ""
+    );
 </script>
 
 <button
@@ -46,9 +66,10 @@
     id="cell-{r}-{c}"
     onmousedown={(e) => onMouseDown(e, r, c)}
     onmouseup={(e) => onMouseUp(e, r, c)}
+    onmouseenter={(e) => onMouseEnter(e, r, c)}
     ontouchstart={(e) => onTouchStart(e, r, c)}
     ontouchend={(e) => onTouchEnd(e, r, c)}
-    class="size-8 flex items-center justify-center border border-gray-400 dark:border-gray-600 text-lg font-mono select-none touch-manipulation text-gray-900 dark:text-gray-100"
+    class="size-8 flex items-center justify-center border border-gray-400 dark:border-gray-600 text-lg font-mono font-bold select-none touch-manipulation {numberColor || 'text-gray-900 dark:text-gray-100'}"
     class:bg-gray-100={cell.isRevealed && !lastStepOnMine}
     class:dark:bg-gray-800={cell.isRevealed && !lastStepOnMine}
     class:bg-gray-200={!cell.isRevealed && isPressed}

--- a/packages/minesweeper/src/state/desktopMouse.svelte.ts
+++ b/packages/minesweeper/src/state/desktopMouse.svelte.ts
@@ -1,3 +1,5 @@
+import type { Board } from "@caiji-games/minesweeper-core";
+
 type MouseAction = {
     leftDown: boolean;
     rightDown: boolean;
@@ -8,6 +10,8 @@ type Options = {
     onReveal: (r: number, c: number) => void;
     onFlag: (r: number, c: number) => void;
     onChord: (r: number, c: number) => void;
+    /** Board snapshot used to decide single-key chord on revealed numbers. */
+    getBoard: () => Board;
     /** Whether mouse interactions are currently allowed (typically false during win/gameover). */
     isInteractive: () => boolean;
 };
@@ -37,6 +41,24 @@ export function createDesktopMouseState(opts: Options) {
         e.stopPropagation();
     }
 
+    // Drag-aim: while any button is held, moving the cursor onto a new cell
+    // updates the press target so the visual preview and the eventual action
+    // follow the cursor (classic Minesweeper behavior).
+    function onMouseEnter(_e: MouseEvent, r: number, c: number) {
+        if (!opts.isInteractive()) return;
+        if (!action.leftDown && !action.rightDown) return;
+        action.position = { r, c };
+    }
+
+    // True iff a left-only press on a revealed number should chord (i.e. the
+    // source cell is a revealed numbered cell — adjacent flags decide whether
+    // the chord actually opens anything; that's the logic layer's call).
+    function isChordSource(r: number, c: number): boolean {
+        const board = opts.getBoard();
+        const cell = board[r]?.[c];
+        return !!cell && cell.isRevealed && !cell.isMine && cell.adjacentMines > 0;
+    }
+
     function onMouseUp(e: MouseEvent, r: number, c: number) {
         if (!opts.isInteractive()) {
             reset();
@@ -46,7 +68,8 @@ export function createDesktopMouseState(opts: Options) {
             if (action.leftDown && action.rightDown) {
                 opts.onChord(r, c);
             } else if (action.leftDown && e.button === 0) {
-                opts.onReveal(r, c);
+                if (isChordSource(r, c)) opts.onChord(r, c);
+                else opts.onReveal(r, c);
             } else if (action.rightDown && e.button === 2) {
                 opts.onFlag(r, c);
             }
@@ -57,27 +80,28 @@ export function createDesktopMouseState(opts: Options) {
 
     /**
      * Visual "pressed" state for a cell. Triggers when:
-     * - User is left-pressing this exact cell, OR
-     * - User is left+right-pressing this cell's neighbor (chord preview).
+     * - User is left-pressing this exact (unrevealed) cell, OR
+     * - User is left+right-pressing this cell's neighbor (two-button chord preview), OR
+     * - User is left-pressing this cell's neighbor that is a revealed number (single-key chord preview).
      */
     function isPressed(r: number, c: number, cellCanPress: boolean): boolean {
         if (!cellCanPress) return false;
         if (!action.leftDown) return false;
         if (action.position.r === r && action.position.c === c) return true;
-        if (
-            action.rightDown &&
-            Math.abs(action.position.r - r) <= 1 &&
-            Math.abs(action.position.c - c) <= 1
-        ) {
-            return true;
-        }
+        const dr = Math.abs(action.position.r - r);
+        const dc = Math.abs(action.position.c - c);
+        if (dr > 1 || dc > 1) return false;
+        if (action.rightDown) return true;
+        if (isChordSource(action.position.r, action.position.c)) return true;
         return false;
     }
 
     return {
         get action() { return action; },
+        get isPressing() { return action.leftDown; },
         onMouseDown,
         onMouseUp,
+        onMouseEnter,
         onLeave: reset,
         isPressed,
     };

--- a/packages/minesweeper/src/state/mobileTouch.svelte.ts
+++ b/packages/minesweeper/src/state/mobileTouch.svelte.ts
@@ -22,7 +22,7 @@ type Options = {
 };
 
 export function createMobileTouchState(opts: Options) {
-    let start: TouchStart | null = null;
+    let start = $state<TouchStart | null>(null);
 
     function onTouchStart(e: TouchEvent, r: number, c: number) {
         if (!opts.isInteractive()) return;
@@ -72,7 +72,13 @@ export function createMobileTouchState(opts: Options) {
         start = null;
     }
 
-    return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel };
+    return {
+        get isPressing() { return start !== null && !start.cancelled; },
+        onTouchStart,
+        onTouchMove,
+        onTouchEnd,
+        onTouchCancel,
+    };
 }
 
 export type MobileTouchState = ReturnType<typeof createMobileTouchState>;


### PR DESCRIPTION
## Summary
This PR enhances the desktop mouse interaction model to support classic Minesweeper behaviors: single-key chording (left-clicking a revealed number to chord) and drag-aim (cursor movement while holding buttons updates the target cell). It also adds visual feedback for number cells with color-coded adjacent mine counts and improves the smiley face emoji to reflect pressing state.

## Key Changes

- **Single-key chord support**: Left-clicking a revealed numbered cell now triggers a chord action instead of a reveal, matching classic Minesweeper behavior. The `isChordSource()` function determines if a cell is a valid chord source (revealed, numbered, non-mine).

- **Drag-aim functionality**: Added `onMouseEnter()` handler to update the press target when the cursor moves over a new cell while any mouse button is held, enabling the visual preview and eventual action to follow the cursor.

- **Board state access**: Added `getBoard()` callback to the mouse state options to allow checking cell properties (revealed status, mine count) for chord detection.

- **Number cell styling**: Implemented classic Minesweeper color palette for adjacent mine counts (1-8) with dark mode variants. Numbers are now displayed in bold with appropriate colors.

- **Visual feedback improvements**: 
  - Added `isPressing` getter to both mouse and touch state modules to expose pressing state
  - Updated smiley face emoji to show "😮" when actively pressing, providing real-time feedback

- **Touch state refactoring**: Converted `start` variable to use Svelte's `$state` rune for proper reactivity and added `isPressing` getter.

- **Updated cell component**: Added `onMouseEnter` event handler and integrated number color styling into the cell template.

## Implementation Details

The `isPressed()` function was refactored to handle three scenarios:
1. Left-pressing an unrevealed cell (original behavior)
2. Left+right-pressing a neighbor (two-button chord preview)
3. Left-pressing a neighbor that is a revealed number (single-key chord preview)

The chord detection logic checks if the source cell is revealed, not a mine, and has adjacent mines > 0, ensuring only valid numbered cells trigger chord actions.

https://claude.ai/code/session_01EQLsqioxPuuNPX9Lmd9T9v