### PR TITLE
Add comprehensive test suites for ads, controls, and state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,21 @@ jobs:
       - name: Run unit tests
         run: pnpm -r run test:run
 
+      # Cube-core has the meaningful pure-logic coverage we publish a badge for. Re-running
+      # under --coverage is a ~1s extra hit; cheaper than threading coverage flags through every
+      # package's test:run script.
+      - name: Collect cube-core coverage
+        run: pnpm --filter @caiji-games/minesweeper-cube-core exec vitest run --coverage --coverage.reporter=lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: packages/minesweeper-cube-core/coverage/lcov.info
+          flags: minesweeper-cube-core
+          # Public repo — no token required. Don't fail the build if the upload hiccups
+          # (codecov occasionally rate-limits or 5xxs; CI greenness shouldn't depend on it).
+          fail_ci_if_error: false
+
   build-web:
     runs-on: ubuntu-latest
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node-compile-cache
 dist
 .next
 out
+coverage
 icons
 target
 gen

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration. The repo has multiple packages; we only publish a coverage badge for
+# minesweeper-cube-core (pure logic with meaningful unit-test coverage). Other packages either
+# have minimal pure logic (state factories in app packages) or are dominated by 3D/Svelte
+# components that can't be measured without a real browser.
+
+coverage:
+  status:
+    project:
+      default:
+        # Don't gate PRs on coverage delta — we treat coverage as informational, not a quality
+        # gate. Threshold is generous so noise from adding new untested branches doesn't fail
+        # CI.
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        informational: true
+
+# Per-package flags. Add new ones as we onboard more packages.
+flag_management:
+  individual_flags:
+    - name: minesweeper-cube-core
+      paths:
+        - packages/minesweeper-cube-core/src/
+
+comment:
+  layout: "diff, flags"
+  require_changes: true

--- a/packages/minesweeper-cube-core/README.md
+++ b/packages/minesweeper-cube-core/README.md
@@ -1,0 +1,24 @@
+# @caiji-games/minesweeper-cube-core
+
+[![codecov](https://codecov.io/gh/HONGJICAI/MineSweeper/branch/main/graph/badge.svg?flag=minesweeper-cube-core)](https://codecov.io/gh/HONGJICAI/MineSweeper)
+
+Pure-logic core for the cube-shaped minesweeper variants. No DOM, no Svelte, no Three.js — just
+the board model, mine placement, reveal/flood/chord rules, and topology (cube-surface neighbors,
+voxel-surface neighbors).
+
+Consumed by the `minesweeper-cube` app package, which layers a Threlte/Three renderer on top.
+
+## Modules
+
+- `cubeLogic` — hollow 6-face cube sweeper: empty-cube construction, seeded mine placement,
+  in-place reveal/flood/chord, win check.
+- `cubeTopology` — face-edge adjacency for an N×N×6 hollow cube. Neighbors cross face seams.
+- `voxelLogic` — solid voxel sweeper: same rules but on the surface cells of an N³ solid cube.
+- `voxelTopology` — surface-voxel adjacency (only cells with at least one face exposed).
+
+## Test
+
+```sh
+pnpm test:run                 # 58 cases
+pnpm exec vitest run --coverage   # local coverage report
+```

--- a/packages/minesweeper-cube-core/package.json
+++ b/packages/minesweeper-cube-core/package.json
@@ -23,6 +23,7 @@
     "test:run": "vitest run"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.7",
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/minesweeper-cube/package.json
+++ b/packages/minesweeper-cube/package.json
@@ -38,6 +38,7 @@
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/three": "^0.184.0",
+    "@vitest/coverage-v8": "^4.1.7",
     "cross-env": "catalog:",
     "happy-dom": "^15.11.7",
     "svelte": "catalog:",

--- a/packages/minesweeper-cube/src/components/cube/cubeControls.test.ts
+++ b/packages/minesweeper-cube/src/components/cube/cubeControls.test.ts
@@ -1,0 +1,371 @@
+// Pointer-driven tests for the orbit camera controls. three.js's math classes (Vector3,
+// Quaternion, PerspectiveCamera) are pure JS — they run fine under happy-dom — so we
+// construct a real camera, attach the controls to a happy-dom <div>, and drive the public
+// surface (pointer events + wheel + update + dispose). No WebGL involved.
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { PerspectiveCamera } from "three";
+import { CubeControls } from "./cubeControls.ts";
+
+const DRAG_THRESHOLD_PX = 6;
+
+// happy-dom doesn't run layout, so element.getBoundingClientRect() returns zeros. The pix-to-rad
+// calibration in rotate() divides by min(width, height) — zero would NaN the camera. Stub a
+// realistic viewport rect so the math comes out finite.
+function setupDom(viewport = { width: 800, height: 600 }) {
+    const dom = document.createElement("div");
+    document.body.appendChild(dom);
+    dom.getBoundingClientRect = () => ({
+        x: 0, y: 0,
+        left: 0, top: 0,
+        right: viewport.width, bottom: viewport.height,
+        width: viewport.width, height: viewport.height,
+        toJSON: () => ({}),
+    });
+    return dom;
+}
+
+function makeCamera() {
+    const cam = new PerspectiveCamera(50, 800 / 600, 0.1, 1000);
+    // Place the camera straight back along +Z so the math has a stable reference.
+    cam.position.set(0, 0, 10);
+    cam.up.set(0, 1, 0);
+    cam.lookAt(0, 0, 0);
+    return cam;
+}
+
+function pointerDown(dom: HTMLElement, opts: { pointerId?: number; clientX: number; clientY: number }) {
+    dom.dispatchEvent(new PointerEvent("pointerdown", {
+        pointerId: opts.pointerId ?? 1,
+        clientX: opts.clientX,
+        clientY: opts.clientY,
+        bubbles: true,
+    }));
+}
+function pointerMove(opts: { pointerId?: number; clientX: number; clientY: number }) {
+    window.dispatchEvent(new PointerEvent("pointermove", {
+        pointerId: opts.pointerId ?? 1,
+        clientX: opts.clientX,
+        clientY: opts.clientY,
+        bubbles: true,
+    }));
+}
+function pointerUp(opts: { pointerId?: number; clientX: number; clientY: number }) {
+    window.dispatchEvent(new PointerEvent("pointerup", {
+        pointerId: opts.pointerId ?? 1,
+        clientX: opts.clientX,
+        clientY: opts.clientY,
+        bubbles: true,
+    }));
+}
+function wheel(dom: HTMLElement, deltaY: number) {
+    dom.dispatchEvent(new WheelEvent("wheel", { deltaY, bubbles: true, cancelable: true }));
+}
+
+describe("CubeControls — construction", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+    });
+    afterEach(() => {
+        controls?.dispose();
+        dom.remove();
+    });
+
+    test("sets touch-action: none on the dom element", () => {
+        controls = new CubeControls(cam, dom);
+        expect(dom.style.touchAction).toBe("none");
+    });
+
+    test("invokes onChange once at construction (camera aimed at target)", () => {
+        let calls = 0;
+        controls = new CubeControls(cam, dom, { onChange: () => calls++ });
+        expect(calls).toBeGreaterThanOrEqual(1);
+    });
+
+    test("applies option defaults", () => {
+        controls = new CubeControls(cam, dom);
+        expect(controls.rotateSpeed).toBe(1);
+        expect(controls.zoomSpeed).toBe(1);
+        expect(controls.minDistance).toBe(0);
+        expect(controls.maxDistance).toBe(Infinity);
+        expect(controls.dampingFactor).toBeCloseTo(0.08);
+        expect(controls.enabled).toBe(true);
+    });
+
+    test("respects custom options", () => {
+        controls = new CubeControls(cam, dom, {
+            rotateSpeed: 2,
+            zoomSpeed: 0.5,
+            minDistance: 3,
+            maxDistance: 20,
+            dampingFactor: 0.2,
+        });
+        expect(controls.rotateSpeed).toBe(2);
+        expect(controls.minDistance).toBe(3);
+        expect(controls.maxDistance).toBe(20);
+        expect(controls.dampingFactor).toBeCloseTo(0.2);
+    });
+});
+
+describe("CubeControls — rotate dead-zone", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+    let posSnapshot: { x: number; y: number; z: number };
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+        controls = new CubeControls(cam, dom);
+        posSnapshot = { x: cam.position.x, y: cam.position.y, z: cam.position.z };
+    });
+    afterEach(() => {
+        controls.dispose();
+        dom.remove();
+    });
+
+    test("sub-threshold drag does NOT move the camera", () => {
+        pointerDown(dom, { clientX: 100, clientY: 100 });
+        pointerMove({ clientX: 100 + (DRAG_THRESHOLD_PX - 1), clientY: 100 });
+        expect(cam.position.x).toBeCloseTo(posSnapshot.x);
+        expect(cam.position.y).toBeCloseTo(posSnapshot.y);
+        expect(cam.position.z).toBeCloseTo(posSnapshot.z);
+        pointerUp({ clientX: 100 + (DRAG_THRESHOLD_PX - 1), clientY: 100 });
+    });
+
+    test("crossing the threshold starts rotation, but the first delta is not the threshold size", () => {
+        // Crossing the threshold by exactly 0 pixels: the *first* qualifying move arms drag.
+        // The next move's delta is what actually rotates — verifying we don't get a snap-rotate
+        // by the threshold value.
+        pointerDown(dom, { clientX: 100, clientY: 100 });
+        pointerMove({ clientX: 100 + DRAG_THRESHOLD_PX + 1, clientY: 100 });
+        const after1 = cam.position.clone();
+        pointerMove({ clientX: 100 + DRAG_THRESHOLD_PX + 2, clientY: 100 });
+        // Tiny additional move → tiny additional change, not a big jump.
+        expect(cam.position.distanceTo(after1)).toBeLessThan(0.1);
+        pointerUp({ clientX: 100 + DRAG_THRESHOLD_PX + 2, clientY: 100 });
+    });
+
+    test("a tap (no drag) leaves no residual velocity for update() to apply", () => {
+        pointerDown(dom, { clientX: 100, clientY: 100 });
+        // Single small move that won't cross the dead zone.
+        pointerMove({ clientX: 102, clientY: 100 });
+        pointerUp({ clientX: 102, clientY: 100 });
+
+        const before = cam.position.clone();
+        // Spin the task loop a bunch — if there were residual velocity it would accumulate.
+        for (let i = 0; i < 30; i++) controls.update();
+        expect(cam.position.distanceTo(before)).toBeLessThan(1e-6);
+    });
+});
+
+describe("CubeControls — rotate produces motion", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+        controls = new CubeControls(cam, dom);
+    });
+    afterEach(() => {
+        controls.dispose();
+        dom.remove();
+    });
+
+    test("a horizontal drag well past threshold rotates the camera", () => {
+        const before = cam.position.clone();
+        pointerDown(dom, { clientX: 400, clientY: 300 });
+        // First move crosses dead-zone (rebases position); second move applies real delta.
+        pointerMove({ clientX: 500, clientY: 300 });
+        pointerMove({ clientX: 600, clientY: 300 });
+        expect(cam.position.distanceTo(before)).toBeGreaterThan(0.1);
+        // Distance to origin is preserved by orbit rotation.
+        expect(cam.position.length()).toBeCloseTo(before.length(), 4);
+        pointerUp({ clientX: 600, clientY: 300 });
+    });
+
+    test("rotation preserves orbit radius across many moves (no drift)", () => {
+        const radius = cam.position.length();
+        pointerDown(dom, { clientX: 400, clientY: 300 });
+        // First crosses dead-zone.
+        pointerMove({ clientX: 411, clientY: 300 });
+        for (let i = 1; i < 20; i++) {
+            pointerMove({ clientX: 411 + i * 20, clientY: 300 + i * 5 });
+        }
+        pointerUp({ clientX: 411 + 19 * 20, clientY: 300 + 19 * 5 });
+        // Allow a hair of FP drift; certainly not >1%.
+        expect(cam.position.length()).toBeCloseTo(radius, 3);
+    });
+
+    test("damping decays residual velocity after release", () => {
+        pointerDown(dom, { clientX: 400, clientY: 300 });
+        pointerMove({ clientX: 411, clientY: 300 });    // crosses dead-zone
+        pointerMove({ clientX: 511, clientY: 300 });    // big delta → high velocity
+        pointerUp({ clientX: 511, clientY: 300 });
+
+        // Capture the first post-release update, then keep ticking until updates stop changing.
+        controls.update();
+        const afterFirstTick = cam.position.clone();
+        let prev = afterFirstTick.clone();
+        let lastDelta = Infinity;
+        for (let i = 0; i < 500; i++) {
+            controls.update();
+            lastDelta = cam.position.distanceTo(prev);
+            prev = cam.position.clone();
+            if (lastDelta < 1e-5) break;
+        }
+        // Should have converged to (near) zero motion within the iteration budget.
+        expect(lastDelta).toBeLessThan(1e-4);
+        // And total movement post-release should be small but non-zero (fling settled).
+        const totalFling = afterFirstTick.distanceTo(prev);
+        expect(totalFling).toBeGreaterThan(0);
+    });
+});
+
+describe("CubeControls — zoom (wheel)", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+    });
+    afterEach(() => {
+        controls.dispose();
+        dom.remove();
+    });
+
+    test("positive deltaY zooms out (radius grows); negative zooms in", () => {
+        controls = new CubeControls(cam, dom);
+        const start = cam.position.length();
+        wheel(dom, 100);
+        const afterOut = cam.position.length();
+        expect(afterOut).toBeGreaterThan(start);
+
+        wheel(dom, -100);
+        const afterIn = cam.position.length();
+        expect(afterIn).toBeLessThan(afterOut);
+    });
+
+    test("wheel zoom clamps at minDistance", () => {
+        controls = new CubeControls(cam, dom, { minDistance: 5 });
+        // Spam zoom-in well past minDistance.
+        for (let i = 0; i < 100; i++) wheel(dom, -100);
+        expect(cam.position.length()).toBeGreaterThanOrEqual(5 - 1e-6);
+    });
+
+    test("wheel zoom clamps at maxDistance", () => {
+        controls = new CubeControls(cam, dom, { maxDistance: 15 });
+        for (let i = 0; i < 100; i++) wheel(dom, 100);
+        expect(cam.position.length()).toBeLessThanOrEqual(15 + 1e-6);
+    });
+
+    test("wheel event is preventDefault'd (so the browser doesn't scroll the page)", () => {
+        controls = new CubeControls(cam, dom);
+        const e = new WheelEvent("wheel", { deltaY: 100, bubbles: true, cancelable: true });
+        dom.dispatchEvent(e);
+        expect(e.defaultPrevented).toBe(true);
+    });
+
+    test("disabled controls ignore wheel", () => {
+        controls = new CubeControls(cam, dom);
+        controls.enabled = false;
+        const before = cam.position.length();
+        wheel(dom, 100);
+        expect(cam.position.length()).toBeCloseTo(before, 6);
+    });
+});
+
+describe("CubeControls — pinch zoom (two pointers)", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+        controls = new CubeControls(cam, dom);
+    });
+    afterEach(() => {
+        controls.dispose();
+        dom.remove();
+    });
+
+    test("widening pinch zooms in (radius shrinks)", () => {
+        const before = cam.position.length();
+        pointerDown(dom, { pointerId: 1, clientX: 300, clientY: 300 });
+        pointerDown(dom, { pointerId: 2, clientX: 500, clientY: 300 }); // initial dist 200
+        // Spread fingers further apart → pinch-zoom in.
+        pointerMove({ pointerId: 1, clientX: 200, clientY: 300 });
+        pointerMove({ pointerId: 2, clientX: 600, clientY: 300 }); // dist 400
+        expect(cam.position.length()).toBeLessThan(before);
+        pointerUp({ pointerId: 1, clientX: 200, clientY: 300 });
+        pointerUp({ pointerId: 2, clientX: 600, clientY: 300 });
+    });
+
+    test("releasing one finger of a pinch resumes rotation with the other", () => {
+        pointerDown(dom, { pointerId: 1, clientX: 300, clientY: 300 });
+        pointerDown(dom, { pointerId: 2, clientX: 500, clientY: 300 });
+        // Lift pointer 2 — pointer 1 should become the rotation pointer with no snap-rotate.
+        pointerUp({ pointerId: 2, clientX: 500, clientY: 300 });
+        const before = cam.position.clone();
+        // A tiny move with pointer 1: still in dead-zone after rebase, so no rotation.
+        pointerMove({ pointerId: 1, clientX: 302, clientY: 300 });
+        expect(cam.position.distanceTo(before)).toBeLessThan(1e-6);
+        // A larger move crosses dead-zone and rotates.
+        pointerMove({ pointerId: 1, clientX: 320, clientY: 300 });
+        pointerMove({ pointerId: 1, clientX: 380, clientY: 300 });
+        expect(cam.position.distanceTo(before)).toBeGreaterThan(0.01);
+        pointerUp({ pointerId: 1, clientX: 380, clientY: 300 });
+    });
+});
+
+describe("CubeControls — enabled flag and dispose", () => {
+    let dom: HTMLElement;
+    let cam: PerspectiveCamera;
+    let controls: CubeControls;
+
+    beforeEach(() => {
+        dom = setupDom();
+        cam = makeCamera();
+    });
+    afterEach(() => {
+        dom.remove();
+    });
+
+    test("enabled=false ignores pointerdown (no rotation)", () => {
+        controls = new CubeControls(cam, dom);
+        controls.enabled = false;
+        const before = cam.position.clone();
+        pointerDown(dom, { clientX: 100, clientY: 100 });
+        pointerMove({ clientX: 200, clientY: 100 });
+        pointerMove({ clientX: 300, clientY: 100 });
+        pointerUp({ clientX: 300, clientY: 100 });
+        expect(cam.position.distanceTo(before)).toBeLessThan(1e-6);
+        controls.dispose();
+    });
+
+    test("dispose restores touch-action and detaches handlers", () => {
+        dom.style.touchAction = "manipulation";
+        controls = new CubeControls(cam, dom);
+        expect(dom.style.touchAction).toBe("none");
+        controls.dispose();
+        expect(dom.style.touchAction).toBe("manipulation");
+
+        // After dispose, events should be inert.
+        const before = cam.position.clone();
+        pointerDown(dom, { clientX: 100, clientY: 100 });
+        pointerMove({ clientX: 200, clientY: 100 });
+        pointerMove({ clientX: 300, clientY: 100 });
+        wheel(dom, 100);
+        expect(cam.position.distanceTo(before)).toBeLessThan(1e-6);
+    });
+});

--- a/packages/minesweeper-cube/src/state/ads.test.svelte.ts
+++ b/packages/minesweeper-cube/src/state/ads.test.svelte.ts
@@ -1,0 +1,481 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { flushSync } from "svelte";
+
+// All plugin entry points are mocked. Each test rewrites the implementations via
+// vi.mocked(...).mockImplementation / mockResolvedValue / mockRejectedValue to drive the
+// success / failure / not-loaded paths.
+vi.mock("tauri-plugin-google-admob-api", () => ({
+    initialize: vi.fn(),
+    showBanner: vi.fn(),
+    hideBanner: vi.fn(),
+    prepareInterstitial: vi.fn(),
+    showInterstitial: vi.fn(),
+    prepareRewarded: vi.fn(),
+    showRewarded: vi.fn(),
+    prepareAppOpen: vi.fn(),
+    showAppOpen: vi.fn(),
+}));
+
+import {
+    initialize,
+    showBanner as showBannerCmd,
+    hideBanner as hideBannerCmd,
+    prepareInterstitial,
+    showInterstitial,
+    prepareRewarded,
+    showRewarded,
+    prepareAppOpen,
+    showAppOpen,
+} from "tauri-plugin-google-admob-api";
+import { createAdsState, type AdsState } from "./ads.svelte.ts";
+
+// Mirrors of the constants in ads.svelte.ts. Kept in sync by hand — change them there, change
+// them here. Asserting the exact numeric values doubles as a guard against silent tweaks.
+const INTERSTITIAL_FREQUENCY = 3;
+const NO_BANNER_DURATION_MS = 24 * 60 * 60 * 1000;
+const APP_OPEN_WAIT_MS = 4000;
+
+function resetPluginMocks() {
+    vi.mocked(initialize).mockReset();
+    vi.mocked(showBannerCmd).mockReset();
+    vi.mocked(hideBannerCmd).mockReset();
+    vi.mocked(prepareInterstitial).mockReset();
+    vi.mocked(showInterstitial).mockReset();
+    vi.mocked(prepareRewarded).mockReset();
+    vi.mocked(showRewarded).mockReset();
+    vi.mocked(prepareAppOpen).mockReset();
+    vi.mocked(showAppOpen).mockReset();
+}
+
+function createInRoot(): { ads: AdsState; cleanup: () => void } {
+    let ads!: AdsState;
+    const cleanup = $effect.root(() => {
+        ads = createAdsState();
+    });
+    return { ads, cleanup };
+}
+
+// `init()` kicks off three preload calls with `void`. They resolve on the microtask queue, so
+// we need to flush microtasks (without advancing fake timers) before asserting flags.
+async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("createAdsState — initial state", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+    });
+
+    test("starts unavailable, no banner, no rewarded", () => {
+        const { ads, cleanup } = createInRoot();
+        expect(ads.available).toBe(false);
+        expect(ads.bannerShown).toBe(false);
+        expect(ads.rewardedReady).toBe(false);
+        expect(ads.noBannerUntil).toBe(0);
+        cleanup();
+    });
+});
+
+describe("init()", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+    });
+
+    test("on success: flips available and triggers all three preloads", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        flushSync();
+
+        expect(ads.available).toBe(true);
+        expect(prepareInterstitial).toHaveBeenCalledTimes(1);
+        expect(prepareRewarded).toHaveBeenCalledTimes(1);
+        expect(prepareAppOpen).toHaveBeenCalledTimes(1);
+        expect(ads.rewardedReady).toBe(true);
+        cleanup();
+    });
+
+    test("on init failure (non-Android platform): stays unavailable, no preloads", async () => {
+        vi.mocked(initialize).mockRejectedValue(new Error("not implemented"));
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        flushSync();
+
+        expect(ads.available).toBe(false);
+        expect(prepareInterstitial).not.toHaveBeenCalled();
+        expect(prepareRewarded).not.toHaveBeenCalled();
+        expect(prepareAppOpen).not.toHaveBeenCalled();
+        cleanup();
+    });
+
+    test("preload failures don't crash init or mark formats ready", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockRejectedValue(new Error("no fill"));
+        vi.mocked(prepareRewarded).mockRejectedValue(new Error("no fill"));
+        vi.mocked(prepareAppOpen).mockRejectedValue(new Error("no fill"));
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        flushSync();
+
+        expect(ads.available).toBe(true);
+        expect(ads.rewardedReady).toBe(false);
+        cleanup();
+    });
+});
+
+describe("showBanner()", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+    });
+
+    test("skips when not available", async () => {
+        const { ads, cleanup } = createInRoot();
+        await ads.showBanner();
+        expect(showBannerCmd).not.toHaveBeenCalled();
+        expect(ads.bannerShown).toBe(false);
+        cleanup();
+    });
+
+    test("shows once and flips bannerShown; second call is a no-op", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showBannerCmd).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        await ads.showBanner();
+        expect(showBannerCmd).toHaveBeenCalledTimes(1);
+        expect(showBannerCmd).toHaveBeenCalledWith(expect.objectContaining({
+            position: "bottom",
+            adSize: "BANNER",
+        }));
+        expect(ads.bannerShown).toBe(true);
+
+        await ads.showBanner();
+        expect(showBannerCmd).toHaveBeenCalledTimes(1);
+        cleanup();
+    });
+
+    test("skips while inside the noBannerUntil reward window", async () => {
+        // Seed a future noBannerUntil before construction so the reactive state picks it up.
+        const future = Date.now() + 60 * 60 * 1000;
+        localStorage.setItem("minesweeper-cube:ads:noBannerUntil", JSON.stringify(future));
+
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        expect(ads.noBannerUntil).toBe(future);
+
+        await ads.showBanner();
+        expect(showBannerCmd).not.toHaveBeenCalled();
+        expect(ads.bannerShown).toBe(false);
+        cleanup();
+    });
+
+    test("shows again once the reward window has expired", async () => {
+        const past = Date.now() - 1;
+        localStorage.setItem("minesweeper-cube:ads:noBannerUntil", JSON.stringify(past));
+
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showBannerCmd).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        await ads.showBanner();
+        expect(showBannerCmd).toHaveBeenCalledTimes(1);
+        cleanup();
+    });
+
+    test("plugin throw leaves bannerShown false (safe to retry)", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showBannerCmd).mockRejectedValue(new Error("network"));
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        await ads.showBanner();
+        expect(showBannerCmd).toHaveBeenCalledTimes(1);
+        expect(ads.bannerShown).toBe(false);
+        cleanup();
+    });
+});
+
+describe("maybeShowInterstitial()", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+    });
+
+    test("skips when not available", async () => {
+        const { ads, cleanup } = createInRoot();
+        await ads.maybeShowInterstitial();
+        expect(showInterstitial).not.toHaveBeenCalled();
+        cleanup();
+    });
+
+    test(`only fires on the ${INTERSTITIAL_FREQUENCY}th completed game`, async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showInterstitial).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        for (let i = 1; i < INTERSTITIAL_FREQUENCY; i++) {
+            await ads.maybeShowInterstitial();
+            expect(showInterstitial).not.toHaveBeenCalled();
+        }
+        await ads.maybeShowInterstitial();
+        expect(showInterstitial).toHaveBeenCalledTimes(1);
+        cleanup();
+    });
+
+    test("counter resets after a successful show", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showInterstitial).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        for (let i = 0; i < INTERSTITIAL_FREQUENCY; i++) await ads.maybeShowInterstitial();
+        expect(showInterstitial).toHaveBeenCalledTimes(1);
+        await flushMicrotasks();
+
+        // Need a fresh preload to land — re-warm was scheduled with `void`.
+        for (let i = 0; i < INTERSTITIAL_FREQUENCY; i++) await ads.maybeShowInterstitial();
+        expect(showInterstitial).toHaveBeenCalledTimes(2);
+        cleanup();
+    });
+
+    test("when preload pending: skips and kicks off a fresh load", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        // Interstitial preload fails so interstitialReady stays false.
+        vi.mocked(prepareInterstitial).mockRejectedValue(new Error("no fill"));
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        const preloadCallsAfterInit = vi.mocked(prepareInterstitial).mock.calls.length;
+
+        for (let i = 0; i < INTERSTITIAL_FREQUENCY; i++) await ads.maybeShowInterstitial();
+        expect(showInterstitial).not.toHaveBeenCalled();
+        // The skip path triggers exactly one additional preload attempt.
+        expect(vi.mocked(prepareInterstitial).mock.calls.length).toBe(preloadCallsAfterInit + 1);
+        cleanup();
+    });
+});
+
+describe("watchRewardedToHideBanner()", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+        vi.useFakeTimers();
+    });
+    afterEach(() => vi.useRealTimers());
+
+    test("returns false when not available", async () => {
+        const { ads, cleanup } = createInRoot();
+        const granted = await ads.watchRewardedToHideBanner();
+        expect(granted).toBe(false);
+        expect(showRewarded).not.toHaveBeenCalled();
+        cleanup();
+    });
+
+    test("returns false when preload hasn't settled and re-kicks the load", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockRejectedValue(new Error("no fill"));
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        const before = vi.mocked(prepareRewarded).mock.calls.length;
+
+        const granted = await ads.watchRewardedToHideBanner();
+        expect(granted).toBe(false);
+        expect(showRewarded).not.toHaveBeenCalled();
+        expect(vi.mocked(prepareRewarded).mock.calls.length).toBe(before + 1);
+        cleanup();
+    });
+
+    test("grants 24h window and hides live banner on full completion", async () => {
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const now = Date.now();
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showBannerCmd).mockResolvedValue({ shown: true } as never);
+        vi.mocked(hideBannerCmd).mockResolvedValue(undefined as never);
+        vi.mocked(showRewarded).mockResolvedValue({
+            shown: true,
+            reward: { type: "coins", amount: 1 },
+        } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        await ads.showBanner();
+        expect(ads.bannerShown).toBe(true);
+
+        const granted = await ads.watchRewardedToHideBanner();
+        expect(granted).toBe(true);
+        expect(ads.noBannerUntil).toBe(now + NO_BANNER_DURATION_MS);
+        expect(hideBannerCmd).toHaveBeenCalledTimes(1);
+        expect(ads.bannerShown).toBe(false);
+        cleanup();
+    });
+
+    test("does NOT grant when user backs out (shown=true, reward=undefined)", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showRewarded).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        const granted = await ads.watchRewardedToHideBanner();
+        expect(granted).toBe(false);
+        expect(ads.noBannerUntil).toBe(0);
+        expect(hideBannerCmd).not.toHaveBeenCalled();
+        cleanup();
+    });
+
+    test("re-preloads after a show so the next call has inventory", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showRewarded).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        const before = vi.mocked(prepareRewarded).mock.calls.length;
+
+        await ads.watchRewardedToHideBanner();
+        await flushMicrotasks();
+        expect(vi.mocked(prepareRewarded).mock.calls.length).toBe(before + 1);
+        cleanup();
+    });
+});
+
+describe("maybeShowAppOpen()", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        resetPluginMocks();
+    });
+
+    test("skips silently when not available", async () => {
+        const { ads, cleanup } = createInRoot();
+        await ads.maybeShowAppOpen();
+        expect(showAppOpen).not.toHaveBeenCalled();
+        cleanup();
+    });
+
+    test("first launch ever: flips the persisted flag and skips the show", async () => {
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        await ads.maybeShowAppOpen();
+        expect(showAppOpen).not.toHaveBeenCalled();
+        flushSync();
+        expect(localStorage.getItem("minesweeper-cube:ads:hasLaunchedBefore")).toBe("true");
+        cleanup();
+    });
+
+    test("subsequent launch with preloaded ad: shows it and re-preloads", async () => {
+        localStorage.setItem("minesweeper-cube:ads:hasLaunchedBefore", "true");
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        vi.mocked(prepareAppOpen).mockResolvedValue(undefined as never);
+        vi.mocked(showAppOpen).mockResolvedValue({ shown: true } as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+        const preloadsBefore = vi.mocked(prepareAppOpen).mock.calls.length;
+
+        await ads.maybeShowAppOpen();
+        await flushMicrotasks();
+        expect(showAppOpen).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(prepareAppOpen).mock.calls.length).toBe(preloadsBefore + 1);
+        cleanup();
+    });
+
+    test("subsequent launch where preload never settles: bails out after APP_OPEN_WAIT_MS", async () => {
+        localStorage.setItem("minesweeper-cube:ads:hasLaunchedBefore", "true");
+        vi.mocked(initialize).mockResolvedValue(undefined as never);
+        vi.mocked(prepareInterstitial).mockResolvedValue(undefined as never);
+        vi.mocked(prepareRewarded).mockResolvedValue(undefined as never);
+        // App-open preload hangs forever (simulates a stuck cold-start network call).
+        vi.mocked(prepareAppOpen).mockReturnValue(new Promise(() => {}) as never);
+
+        const { ads, cleanup } = createInRoot();
+        await ads.init();
+        await flushMicrotasks();
+
+        vi.useFakeTimers();
+        const promise = ads.maybeShowAppOpen();
+        // Drive past the deadline. The polling loop sleeps 100ms at a time, so we advance
+        // through several intervals to give the while-loop a chance to exit.
+        await vi.advanceTimersByTimeAsync(APP_OPEN_WAIT_MS + 200);
+        await promise;
+        vi.useRealTimers();
+
+        expect(showAppOpen).not.toHaveBeenCalled();
+        cleanup();
+    });
+});

--- a/packages/minesweeper-cube/src/state/happyPath.test.svelte.ts
+++ b/packages/minesweeper-cube/src/state/happyPath.test.svelte.ts
@@ -1,0 +1,210 @@
+// Integration test that exercises the cross-store wiring the way App.svelte does. The recording
+// effect that turns a Win/GameOver into a leaderboard + history + unlocks update lives inside
+// App.svelte, so a regression there (e.g. losses recorded as wins, unlocks not progressing) is
+// invisible to the per-store unit tests. This file composes the same factories, attaches a
+// mirror of that effect, and drives a full classic-mode win and loss end-to-end.
+//
+// Caveats: the renderer is not exercised here (no Threlte / Three / WebGL in node). What this
+// covers is the pure state-and-rules surface — the same surface a Playwright run would also
+// touch, but without the cost / flake.
+
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { flushSync } from "svelte";
+import {
+    FACES,
+    GameStatus,
+    type Cube,
+    type CubePosition,
+} from "@caiji-games/minesweeper-cube-core";
+import { createTimerState } from "@caiji-games/shared-state";
+import { createGameState } from "./game.svelte.ts";
+import { createLeaderboardState } from "./leaderboard.svelte.ts";
+import { createPlayHistoryState } from "./playHistory.svelte.ts";
+import { createUnlockState } from "./unlocks.svelte.ts";
+
+// Mirror the recording effect from App.svelte. Kept in lockstep with App.svelte; if you change
+// the recording rules there, update this helper.
+function attachRecordingEffect(
+    game: ReturnType<typeof createGameState>,
+    timer: ReturnType<typeof createTimerState>,
+    leaderboard: ReturnType<typeof createLeaderboardState>,
+    history: ReturnType<typeof createPlayHistoryState>,
+) {
+    let prevStatus: GameStatus = game.status;
+    let prevRunId: number = game.runId;
+    $effect(() => {
+        const s = game.status;
+        const r = game.runId;
+        if (r !== prevRunId) timer.reset();
+        if (s === GameStatus.Gaming && game.transitionPhase === "idle") timer.start();
+        else timer.stop();
+        if (s === GameStatus.Init && r !== prevRunId) timer.reset();
+
+        if (prevStatus !== s && (s === GameStatus.Win || s === GameStatus.GameOver)) {
+            if (game.mode === "classic") {
+                const entry = {
+                    result: s === GameStatus.Win ? ("Win" as const) : ("Loss" as const),
+                    time: timer.seconds,
+                    date: new Date().toISOString(),
+                };
+                if (s === GameStatus.Win) leaderboard.add(game.difficulty, entry);
+                history.addEntry(game.difficulty, entry);
+            }
+        }
+        prevStatus = s;
+        prevRunId = r;
+    });
+}
+
+// Mirror the unlock-progression effect from App.svelte.
+function attachUnlockEffect(
+    leaderboard: ReturnType<typeof createLeaderboardState>,
+    unlocks: ReturnType<typeof createUnlockState>,
+) {
+    $effect(() => {
+        if (leaderboard.boards.easy.length > 0) unlocks.unlock("medium");
+        if (leaderboard.boards.medium.length > 0) unlocks.unlock("hard");
+    });
+}
+
+// Plays the game to a win by revealing one corner (which triggers mine placement) then sweeping
+// every remaining non-mine cell. Skipping already-revealed cells is handled inside reveal().
+function playToWin(game: ReturnType<typeof createGameState>) {
+    const seed: CubePosition = { face: "F", r: 0, c: 0 };
+    game.reveal(seed);
+    const N = game.N;
+    const cube = game.cube as Cube;
+    for (const face of FACES) {
+        for (let r = 0; r < N; r++) {
+            for (let c = 0; c < N; c++) {
+                if (!cube[face][r][c].isMine) game.reveal({ face, r, c });
+            }
+        }
+    }
+}
+
+// Plays the game to a loss by revealing one safe cell to seed mine placement, then stepping on
+// the first mine we can find.
+function playToLoss(game: ReturnType<typeof createGameState>) {
+    const seed: CubePosition = { face: "F", r: 0, c: 0 };
+    game.reveal(seed);
+    const N = game.N;
+    const cube = game.cube as Cube;
+    for (const face of FACES) {
+        for (let r = 0; r < N; r++) {
+            for (let c = 0; c < N; c++) {
+                if (cube[face][r][c].isMine) {
+                    game.reveal({ face, r, c });
+                    return;
+                }
+            }
+        }
+    }
+    throw new Error("test setup bug: no mine found after generation");
+}
+
+describe("happy path — classic easy", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        // Pin timer math so leaderboard `time` values are deterministic.
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    test("full win records leaderboard + history and unlocks medium", () => {
+        let game!: ReturnType<typeof createGameState>;
+        let leaderboard!: ReturnType<typeof createLeaderboardState>;
+        let history!: ReturnType<typeof createPlayHistoryState>;
+        let unlocks!: ReturnType<typeof createUnlockState>;
+
+        const cleanup = $effect.root(() => {
+            game = createGameState("easy");
+            const timer = createTimerState();
+            leaderboard = createLeaderboardState();
+            history = createPlayHistoryState();
+            unlocks = createUnlockState();
+            attachRecordingEffect(game, timer, leaderboard, history);
+            attachUnlockEffect(leaderboard, unlocks);
+        });
+
+        // Pre-conditions: only easy is unlocked.
+        expect(unlocks.easy).toBe(true);
+        expect(unlocks.medium).toBe(false);
+        expect(unlocks.hard).toBe(false);
+
+        playToWin(game);
+        flushSync();
+
+        expect(game.status).toBe(GameStatus.Win);
+        expect(leaderboard.boards.easy).toHaveLength(1);
+        expect(leaderboard.boards.easy[0].result).toBe("Win");
+        expect(history.map.easy).toHaveLength(1);
+        expect(history.map.easy[0].result).toBe("Win");
+        // Medium unlocks from the leaderboard-driven effect; hard stays locked until medium win.
+        expect(unlocks.medium).toBe(true);
+        expect(unlocks.hard).toBe(false);
+        cleanup();
+    });
+
+    test("loss records only history (not leaderboard) and does NOT unlock medium", () => {
+        let game!: ReturnType<typeof createGameState>;
+        let leaderboard!: ReturnType<typeof createLeaderboardState>;
+        let history!: ReturnType<typeof createPlayHistoryState>;
+        let unlocks!: ReturnType<typeof createUnlockState>;
+
+        const cleanup = $effect.root(() => {
+            game = createGameState("easy");
+            const timer = createTimerState();
+            leaderboard = createLeaderboardState();
+            history = createPlayHistoryState();
+            unlocks = createUnlockState();
+            attachRecordingEffect(game, timer, leaderboard, history);
+            attachUnlockEffect(leaderboard, unlocks);
+        });
+
+        playToLoss(game);
+        flushSync();
+
+        expect(game.status).toBe(GameStatus.GameOver);
+        expect(leaderboard.boards.easy).toEqual([]);
+        expect(history.map.easy).toHaveLength(1);
+        expect(history.map.easy[0].result).toBe("Loss");
+        expect(unlocks.medium).toBe(false);
+        cleanup();
+    });
+
+    test("state survives full rehydration after a win", () => {
+        // Round 1: win and let persistence flush.
+        const c1 = $effect.root(() => {
+            const game = createGameState("easy");
+            const timer = createTimerState();
+            const leaderboard = createLeaderboardState();
+            const history = createPlayHistoryState();
+            const unlocks = createUnlockState();
+            attachRecordingEffect(game, timer, leaderboard, history);
+            attachUnlockEffect(leaderboard, unlocks);
+            playToWin(game);
+        });
+        flushSync();
+        c1();
+
+        // Round 2: fresh factories, same localStorage — should reflect round 1's win.
+        let leaderboard!: ReturnType<typeof createLeaderboardState>;
+        let history!: ReturnType<typeof createPlayHistoryState>;
+        let unlocks!: ReturnType<typeof createUnlockState>;
+        const c2 = $effect.root(() => {
+            leaderboard = createLeaderboardState();
+            history = createPlayHistoryState();
+            unlocks = createUnlockState();
+            // Same migration path as a returning user: the unlock effect re-runs with rehydrated
+            // leaderboard data and re-grants unlocks.
+            attachUnlockEffect(leaderboard, unlocks);
+        });
+
+        expect(leaderboard.boards.easy).toHaveLength(1);
+        expect(history.map.easy).toHaveLength(1);
+        expect(unlocks.medium).toBe(true);
+        c2();
+    });
+});

--- a/packages/minesweeper-cube/src/state/persistedFallback.test.svelte.ts
+++ b/packages/minesweeper-cube/src/state/persistedFallback.test.svelte.ts
@@ -1,0 +1,166 @@
+// Defensive-load tests: every consumer of `persistedState` must survive a localStorage value
+// that's truncated, garbage, or shaped differently than the current schema. Schema migrations
+// will happen post-launch, and v1 users carrying v0 data must not see a white screen.
+//
+// The fallback contract is implemented inside @caiji-games/shared-state's persistedState: a
+// failed JSON.parse returns the supplied initial value. JSON that parses but doesn't match the
+// expected shape is returned as-is — consumers carry the responsibility for being defensive,
+// so the tests below exercise each one with realistic bad payloads.
+
+import { describe, test, expect, beforeEach } from "vitest";
+import { flushSync } from "svelte";
+import { createUnlockState } from "./unlocks.svelte.ts";
+import { createLeaderboardState } from "./leaderboard.svelte.ts";
+import { createEndlessHistoryState } from "./endlessHistory.svelte.ts";
+import { createPlayHistoryState } from "./playHistory.svelte.ts";
+
+const KEY = (suffix: string) => `minesweeper-cube:${suffix}`;
+
+describe("unlocks — corrupt persisted payloads", () => {
+    beforeEach(() => localStorage.clear());
+
+    test("garbage JSON falls back to defaults", () => {
+        localStorage.setItem(KEY("unlocks"), "{not json");
+
+        let st!: ReturnType<typeof createUnlockState>;
+        const c = $effect.root(() => { st = createUnlockState(); });
+        expect(st.easy).toBe(true);
+        expect(st.medium).toBe(false);
+        expect(st.hard).toBe(false);
+        c();
+    });
+
+    test("empty string falls back to defaults", () => {
+        localStorage.setItem(KEY("unlocks"), "");
+
+        let st!: ReturnType<typeof createUnlockState>;
+        const c = $effect.root(() => { st = createUnlockState(); });
+        expect(st.easy).toBe(true);
+        c();
+    });
+
+    test("can still unlock after loading garbage", () => {
+        localStorage.setItem(KEY("unlocks"), "garbage");
+
+        let st!: ReturnType<typeof createUnlockState>;
+        const c = $effect.root(() => { st = createUnlockState(); });
+        st.unlock("medium");
+        flushSync();
+        expect(st.medium).toBe(true);
+        c();
+    });
+});
+
+describe("leaderboard — corrupt persisted payloads", () => {
+    beforeEach(() => localStorage.clear());
+
+    test("malformed JSON: empty boards, add still works", () => {
+        localStorage.setItem(KEY("leaderboards"), "}{");
+
+        let lb!: ReturnType<typeof createLeaderboardState>;
+        const c = $effect.root(() => { lb = createLeaderboardState(); });
+        expect(lb.boards.easy).toEqual([]);
+        expect(lb.boards.medium).toEqual([]);
+        expect(lb.boards.hard).toEqual([]);
+
+        lb.add("easy", { result: "Win", time: 12, date: "2026-01-01T00:00:00.000Z" });
+        flushSync();
+        expect(lb.boards.easy).toHaveLength(1);
+        c();
+    });
+
+    test("truncated JSON survives", () => {
+        // Looks like the start of a serialized board map, but cut mid-value.
+        localStorage.setItem(KEY("leaderboards"), '{"easy":[{"result":"Wi');
+
+        let lb!: ReturnType<typeof createLeaderboardState>;
+        const c = $effect.root(() => { lb = createLeaderboardState(); });
+        expect(lb.boards.easy).toEqual([]);
+        c();
+    });
+});
+
+describe("endlessHistory — corrupt persisted payloads", () => {
+    beforeEach(() => localStorage.clear());
+
+    test("garbage JSON: empty history, addRun still works", () => {
+        localStorage.setItem(KEY("endlessHistory:normal"), "nope");
+
+        let h!: ReturnType<typeof createEndlessHistoryState>;
+        const c = $effect.root(() => { h = createEndlessHistoryState("normal"); });
+        expect(h.all).toEqual([]);
+        expect(h.topByLevel).toEqual([]);
+
+        h.addRun({ maxLevel: 9, time: 120, date: "2026-01-01T00:00:00.000Z" });
+        flushSync();
+        expect(h.all).toHaveLength(1);
+        c();
+    });
+
+    test("modes have separate buckets — corrupting one doesn't poison the other", () => {
+        localStorage.setItem(KEY("endlessHistory:voxel"), "garbage");
+        localStorage.setItem(
+            KEY("endlessHistory:normal"),
+            JSON.stringify([{ maxLevel: 12, time: 300, date: "2026-01-01T00:00:00.000Z" }]),
+        );
+
+        let voxel!: ReturnType<typeof createEndlessHistoryState>;
+        let normal!: ReturnType<typeof createEndlessHistoryState>;
+        const c = $effect.root(() => {
+            voxel = createEndlessHistoryState("voxel");
+            normal = createEndlessHistoryState("normal");
+        });
+        expect(voxel.all).toEqual([]);
+        expect(normal.all).toHaveLength(1);
+        expect(normal.all[0].maxLevel).toBe(12);
+        c();
+    });
+});
+
+describe("playHistory — corrupt persisted payloads", () => {
+    beforeEach(() => localStorage.clear());
+
+    test("garbage JSON: empty per-difficulty map, addEntry still works", () => {
+        localStorage.setItem(KEY("playHistory"), "###");
+
+        let h!: ReturnType<typeof createPlayHistoryState>;
+        const c = $effect.root(() => { h = createPlayHistoryState(); });
+        expect(h.map.easy).toEqual([]);
+        expect(h.map.medium).toEqual([]);
+        expect(h.map.hard).toEqual([]);
+
+        h.addEntry("easy", { result: "Win", time: 9, date: "2026-01-01T00:00:00.000Z" });
+        flushSync();
+        expect(h.map.easy).toHaveLength(1);
+        c();
+    });
+});
+
+describe("ads — corrupt persisted payloads", () => {
+    beforeEach(() => localStorage.clear());
+
+    test("garbage noBannerUntil falls back to 0 (banner not suppressed)", async () => {
+        localStorage.setItem(KEY("ads:noBannerUntil"), "not-a-number");
+
+        // We don't call init() — just read the public getter to confirm the fallback.
+        // Dynamically import to avoid hoisting issues with vi.mock in sibling files.
+        const { createAdsState } = await import("./ads.svelte.ts");
+        let ads!: ReturnType<typeof createAdsState>;
+        const c = $effect.root(() => { ads = createAdsState(); });
+        expect(ads.noBannerUntil).toBe(0);
+        c();
+    });
+
+    test("garbage hasLaunchedBefore: treated as never-launched (the safe default)", async () => {
+        localStorage.setItem(KEY("ads:hasLaunchedBefore"), "{{{");
+
+        const { createAdsState } = await import("./ads.svelte.ts");
+        let ads!: ReturnType<typeof createAdsState>;
+        const c = $effect.root(() => { ads = createAdsState(); });
+        // Indirect check: noBannerUntil getter is exposed; hasLaunchedBefore isn't. The
+        // observable consequence is in maybeShowAppOpen behaviour, which the ads test file
+        // covers. Here we just confirm construction doesn't throw on the garbage payload.
+        expect(ads.available).toBe(false);
+        c();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@20.19.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
+        version: 4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
 
   packages/minesweeper-cube:
     dependencies:
@@ -162,6 +162,9 @@ importers:
       '@types/three':
         specifier: ^0.184.0
         version: 0.184.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.5)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -188,10 +191,13 @@ importers:
         version: 1.2.0(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@20.19.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
+        version: 4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
 
   packages/minesweeper-cube-core:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.5)
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -200,7 +206,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@20.19.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
+        version: 4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
 
   packages/shared-state:
     devDependencies:
@@ -282,7 +288,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@20.19.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
+        version: 4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
 
 packages:
 
@@ -812,6 +818,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -1060,6 +1070,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1469,6 +1482,15 @@ packages:
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1486,6 +1508,9 @@ packages:
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
   '@vitest/runner@4.1.5':
     resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
@@ -1497,6 +1522,9 @@ packages:
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1549,6 +1577,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.2:
+    resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1984,6 +2015,10 @@ packages:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -2006,6 +2041,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -2142,6 +2180,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -2157,6 +2207,9 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2302,6 +2355,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2535,6 +2595,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
@@ -2663,6 +2728,10 @@ packages:
   strip-comments@2.0.1:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -3170,7 +3239,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -3800,6 +3869,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -3954,7 +4025,7 @@ snapshots:
   '@jridgewell/source-map@0.3.11':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
@@ -3964,6 +4035,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4318,6 +4394,20 @@ snapshots:
 
   '@types/webxr@0.5.24': {}
 
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.2
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4339,6 +4429,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/runner@4.1.5':
     dependencies:
       '@vitest/utils': 4.1.5
@@ -4356,6 +4450,12 @@ snapshots:
   '@vitest/utils@4.1.5':
     dependencies:
       '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -4420,6 +4520,12 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.2:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -4917,6 +5023,8 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
+  has-flag@4.0.0: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -4941,6 +5049,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
+
+  html-escaper@2.0.2: {}
 
   idb@7.1.1: {}
 
@@ -5077,6 +5187,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -5094,6 +5217,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.4.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5224,6 +5349,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   math-intrinsics@1.1.0: {}
 
@@ -5477,6 +5612,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.8.1: {}
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -5648,6 +5785,10 @@ snapshots:
       ansi-regex: 6.1.0
 
   strip-comments@2.0.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -5906,7 +6047,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2)
 
-  vitest@4.1.5(@types/node@20.19.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2)):
+  vitest@4.1.5(@types/node@20.19.7)(@vitest/coverage-v8@4.1.7)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@20.19.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.46.2))
@@ -5930,6 +6071,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.7
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.5)
       happy-dom: 15.11.7
       jsdom: 29.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
This PR adds four comprehensive test suites covering critical game functionality: ad system integration, camera controls, cross-store state wiring, and defensive data loading.

## Key Changes

- **ads.test.svelte.ts** (481 lines): Complete test coverage for the ad system including:
  - Plugin initialization and preload lifecycle
  - Banner display with reward window suppression
  - Interstitial frequency-based triggering with counter reset
  - Rewarded video completion and 24-hour banner suppression window
  - App-open ad display with launch detection and timeout handling
  - Error resilience and retry safety

- **cubeControls.test.ts** (371 lines): Full pointer/wheel interaction tests for orbit camera:
  - Dead-zone threshold validation (6px) to prevent accidental rotation on taps
  - Drag-to-rotate with orbit radius preservation across many moves
  - Damping/fling decay after pointer release
  - Wheel zoom with min/max distance clamping
  - Two-pointer pinch zoom with seamless single-pointer fallback
  - Enabled flag and proper cleanup/disposal

- **happyPath.test.svelte.ts** (210 lines): Integration test exercising full game flow:
  - Win/loss recording to leaderboard and history
  - Unlock progression (easy → medium → hard)
  - State persistence and rehydration across app restarts
  - Mirrors the recording and unlock effects from App.svelte

- **persistedFallback.test.svelte.ts** (166 lines): Defensive loading tests for all persisted state:
  - Garbage JSON, truncated data, and malformed payloads
  - Fallback to sensible defaults without crashing
  - Continued functionality after loading corrupt data
  - Per-mode isolation in endless history

## Notable Implementation Details

- Tests use Svelte's `$effect.root()` for proper reactive state initialization
- Ad tests mock the entire `tauri-plugin-google-admob-api` surface with configurable success/failure paths
- Camera control tests stub `getBoundingClientRect()` since happy-dom doesn't run layout
- Integration test mirrors App.svelte's recording and unlock effects to catch cross-store wiring regressions
- Defensive tests verify that schema migrations won't break v1 users carrying v0 data

https://claude.ai/code/session_01ASUj7S9idsfQPRKU4ktjvg